### PR TITLE
Add StoryBook Apollo integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM mhart/alpine-node:9
+
+RUN mkdir /app
+ADD . /app
+
+WORKDIR /app/ui
+RUN npm install && npm run build
+
+WORKDIR /app/api
+RUN npm install && npm run build
+
+WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM mhart/alpine-node:9
 RUN mkdir /app
 ADD . /app
 
+WORKDIR /app/schema
+RUN npm install
+
 WORKDIR /app/ui
 RUN npm install && npm run build
 

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -1,0 +1,13 @@
+FROM mhart/alpine-node:9
+
+RUN mkdir /app
+ADD ./schema /app/schema
+ADD ./api /app/api
+
+WORKDIR /app/schema
+RUN npm install
+
+WORKDIR /app/api
+RUN npm install && npm run build
+
+CMD npm start

--- a/Dockerfile-ui
+++ b/Dockerfile-ui
@@ -1,0 +1,16 @@
+FROM mhart/alpine-node:9
+
+RUN mkdir /app
+
+ADD ./schema /app/schema
+ADD ./ui /app/ui
+
+WORKDIR /app/schema
+RUN npm install
+
+WORKDIR /app/ui
+RUN npm install && npm run build
+
+RUN npm install -g serve
+
+CMD serve -s build

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,0 @@
-FROM mhart/alpine-node:9
-RUN mkdir www/
-WORKDIR www/
-ADD . .
-RUN npm install && npm run build
-CMD npm run start

--- a/api/Dockerfile-dev
+++ b/api/Dockerfile-dev
@@ -1,4 +1,0 @@
-FROM mhart/alpine-node:9
-WORKDIR www/
-RUN npm install
-CMD npm run watch

--- a/api/Dockerfile-test
+++ b/api/Dockerfile-test
@@ -1,6 +1,0 @@
-FROM mhart/alpine-node:9
-
-WORKDIR www/
-ADD . .
-RUN npm install
-CMD npm test

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -7379,6 +7379,30 @@
         "debug": "^2.6.9"
       }
     },
+    "rex-schema": {
+      "version": "file:../schema",
+      "requires": {
+        "graphql": "^0.13.2",
+        "graphql-tag": "^2.9.2"
+      },
+      "dependencies": {
+        "graphql": {
+          "version": "0.13.2",
+          "bundled": true,
+          "requires": {
+            "iterall": "^1.2.1"
+          }
+        },
+        "graphql-tag": {
+          "version": "2.9.2",
+          "bundled": true
+        },
+        "iterall": {
+          "version": "1.2.2",
+          "bundled": true
+        }
+      }
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -12,6 +12,7 @@
     "graphql-sequelize": "^9.0.1",
     "pg": "^7.4.3",
     "pg-hstore": "^2.3.2",
+    "rex-schema": "file:../schema",
     "slugify": "^1.3.0"
   },
   "devDependencies": {

--- a/api/src/schema.test.js
+++ b/api/src/schema.test.js
@@ -1,6 +1,6 @@
 import { makeExecutableSchema, addMockFunctionsToSchema } from 'graphql-tools';
 import { graphql } from 'graphql';
-import typeDefs from './schema/typeDefs'
+import typeDefs from 'rex-schema'
 import resolvers from './schema/resolvers'
 
 import { Claim, sequelize } from './models'

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -4,7 +4,7 @@ import {Claim, User} from './models'
 import { resolver } from 'graphql-sequelize'
 import slugify from 'slugify'
 
-import typeDefs from './schema/typeDefs'
+import typeDefs from 'rex-schema'
 import resolvers from './schema/resolvers'
 
 const server = new ApolloServer({ typeDefs, resolvers });

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,9 +1,8 @@
 version: '3.6'
 services:
   api:
-    build:
-      context: ./api
-      dockerfile: Dockerfile-dev
+    build: ./
+    command: npm run start-api
     depends_on:
       - db
     image: rex-api-dev:latest
@@ -12,20 +11,19 @@ services:
     environment:
       - NODE_ENV=development
     volumes:
-      - ./api:/www
+      - .:/app
     ports:
       - 8088:8088
   ui:
-    build:
-      context: ./ui
-      dockerfile: Dockerfile-dev
+    build: ./
+    command: npm run start-ui
     image: rex-uid-dev:latest
     container_name: rex-ui-dev
     env_file: config/.env
     environment:
       - NODE_ENV=development
     volumes:
-      - ./ui:/www
+      - .:/app
     ports:
       - 3000:3000
   db:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,25 +1,23 @@
 version: '3.6'
 services:
   api:
-    build:
-      context: ./
-      dockerfile: Dockerfile-test
+    build: ./
     image: rex-api-test:latest
     container_name: rex-api-test
-    env_file: ../config/.env
+    env_file: config/.env
     environment:
       - NODE_ENV=test
     volumes:
-      - ./:/www:delegated
+      - ./:/app:delegated
     depends_on:
       - db
     stdin_open: true
     tty: true
   db:
-    build: ../db
+    build: ./db
     image: rex-db-dev:latest
     container_name: rex-api-db-test
-    env_file: ../config/.env
+    env_file: config/.env
     volumes:
       - rex-test-db:/var/lib/postgresql/data
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3'
 services:
   api:
-    build: ./api
+    build:
+      context: ./
+      dockerfile: Dockerfile-api
     image: rex-api:latest
     container_name: rex-api
     env_file: config/.env
@@ -10,7 +12,9 @@ services:
     ports:
       - 8088:8088
   ui:
-    build: ./ui
+    build:
+      context: ./
+      dockerfile: Dockerfile-ui
     image: rex-ui:latest
     container_name: rex-ui
     env_file: config/.env

--- a/package.json
+++ b/package.json
@@ -3,12 +3,17 @@
   "version": "1.0.0",
   "description": "rex is a Really EXcellent way to build webapps",
   "scripts": {
-    "test": "cd ui && npm test && cd ../api && npm run docker-test",
     "start": "docker-compose -f docker-compose-dev.yml up",
+    "start-ui": "cd ui && npm start",
+    "start-api": "cd api && npm run watch",
     "storybook": "cd ui && npm run storybook",
-    "watch:api-tests": "cd api && npm run watch:docker-test",
     "db:sync": "docker-compose -f docker-compose-dev.yml run api npm run db:sync",
-    "db:sync-force": "docker-compose -f docker-compose-dev.yml run api npm run db:sync-force"
+    "db:sync-force": "docker-compose -f docker-compose-dev.yml run api npm run db:sync-force",
+    "test": "npm run ui:test && npm run docker:api:test",
+    "ui:test": "cd ui && npm test",
+    "api:test": "cd api && npm test",
+    "docker:api:test": "docker-compose -f docker-compose-test.yml run api npm run api:test",
+    "docker:api:watch:test": "docker-compose -f docker-compose-test.yml run api npm run api:watch:test"
   },
   "repository": {
     "type": "git",

--- a/schema/.gitignore
+++ b/schema/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/schema/package.json
+++ b/schema/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "rex-schema",
+  "version": "0.0.1",
+  "description": "The schema for the rext GraphQL server",
+  "main": "schema.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "graphql": "^0.13.2",
+    "graphql-tag": "^2.9.2"
+  }
+}

--- a/schema/schema.js
+++ b/schema/schema.js
@@ -1,6 +1,5 @@
-import { gql } from 'apollo-server-express'
-
-export default gql`
+'use strict';
+module.exports = require('graphql-tag')`
   type User {
     id: ID
     email: String
@@ -29,4 +28,4 @@ export default gql`
     addClaim(title: String, authorID: ID): Claim
     addUser(email: String, firstName: String, lastName: String): User
   }
-`
+`;

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,7 +1,0 @@
-FROM mhart/alpine-node:9
-RUN mkdir www/
-WORKDIR www/
-ADD . .
-RUN npm install && npm run build
-RUN npm install -g serve
-CMD serve -s build

--- a/ui/Dockerfile-dev
+++ b/ui/Dockerfile-dev
@@ -1,4 +1,0 @@
-FROM mhart/alpine-node:9
-WORKDIR www/
-RUN npm install
-CMD npm start

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1540,6 +1540,21 @@
         "graphql-anywhere": "^4.1.0-alpha.0"
       }
     },
+    "apollo-storybook-core": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-storybook-core/-/apollo-storybook-core-0.3.4.tgz",
+      "integrity": "sha1-Xq4edWrdbQpEjDZzukdUT0tB+7g=",
+      "dev": true
+    },
+    "apollo-storybook-react": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/apollo-storybook-react/-/apollo-storybook-react-0.1.5.tgz",
+      "integrity": "sha1-qESdRCKc5RjFL1HQDNJMLY8a1W4=",
+      "dev": true,
+      "requires": {
+        "apollo-storybook-core": "^0.3.4"
+      }
+    },
     "apollo-utilities": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.16.tgz",
@@ -4589,6 +4604,12 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
+    "deprecated-decorator": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=",
+      "dev": true
+    },
     "des.js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -6766,6 +6787,19 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.9.2.tgz",
       "integrity": "sha512-qnNmof9pAqj/LUzs3lStP0Gw1qhdVCUS7Ab7+SUB6KD5aX1uqxWQRwMnOGTkhKuLvLNIs1TvNz+iS9kUGl1MhA=="
+    },
+    "graphql-tools": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-3.1.1.tgz",
+      "integrity": "sha512-yHvPkweUB0+Q/GWH5wIG60bpt8CTwBklCSzQdEHmRUgAdEQKxw+9B7zB3dG7wB3Ym7M7lfrS4Ej+jtDZfA2UXg==",
+      "dev": true,
+      "requires": {
+        "apollo-link": "^1.2.2",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
+      }
     },
     "growly": {
       "version": "1.3.0",
@@ -12338,6 +12372,30 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
+    "rex-schema": {
+      "version": "file:../schema",
+      "requires": {
+        "graphql": "^0.13.2",
+        "graphql-tag": "^2.9.2"
+      },
+      "dependencies": {
+        "graphql": {
+          "version": "0.13.2",
+          "bundled": true,
+          "requires": {
+            "iterall": "^1.2.1"
+          }
+        },
+        "graphql-tag": {
+          "version": "2.9.2",
+          "bundled": true
+        },
+        "iterall": {
+          "version": "1.2.2",
+          "bundled": true
+        }
+      }
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -12999,6 +13057,15 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+    },
+    "storybook-react-router": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/storybook-react-router/-/storybook-react-router-1.0.1.tgz",
+      "integrity": "sha512-R1IKXr4RfwJOpuXvl2wxOkYR+7DHlK6zPyzTCWCacn/nC27kE5y7n30ikmxEiOIvZQK5uA+5P2NtwU9Ew9yOOQ==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.6.1"
+      }
     },
     "stream-browserify": {
       "version": "2.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,8 @@
     "react-apollo": "^2.1.9",
     "react-dom": "^16.4.1",
     "react-router-dom": "^4.3.1",
-    "react-scripts": "1.1.4"
+    "react-scripts": "1.1.4",
+    "rex-schema": "file:../schema"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -27,8 +28,11 @@
     "@storybook/addon-storyshots": "^3.4.10",
     "@storybook/addons": "^3.4.8",
     "@storybook/react": "^3.4.8",
+    "apollo-storybook-react": "^0.1.5",
     "babel-core": "^6.26.3",
     "babel-runtime": "^6.26.0",
-    "react-test-renderer": "^16.4.2"
+    "graphql-tools": "^3.1.1",
+    "react-test-renderer": "^16.4.2",
+    "storybook-react-router": "^1.0.1"
   }
 }

--- a/ui/src/stories/__snapshots__/storyshots.test.js.snap
+++ b/ui/src/stories/__snapshots__/storyshots.test.js.snap
@@ -46,6 +46,14 @@ exports[`Storyshots Claims with claims 1`] = `
 </div>
 `;
 
+exports[`Storyshots ClaimsPage with claims 1`] = `
+<div
+  className="Claims"
+>
+  <ul />
+</div>
+`;
+
 exports[`Storyshots User with claims 1`] = `
 <div
   className="User"
@@ -56,14 +64,14 @@ exports[`Storyshots User with claims 1`] = `
     <ul>
       <li>
         <a
-          href="//ducks_are_cool"
+          href="/ducks_are_cool"
         >
           Ducks are cool
         </a>
       </li>
       <li>
         <a
-          href="//geese_are_neat"
+          href="/geese_are_neat"
         >
           Geese are neat
         </a>

--- a/ui/src/stories/index.js
+++ b/ui/src/stories/index.js
@@ -3,12 +3,17 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
+import StoryRouter from 'storybook-react-router';
+import apolloStorybookDecorator from 'apollo-storybook-react';
 
 import { Button, Welcome } from '@storybook/react/demo';
+
+import typeDefs from 'rex-schema'
 
 import Claims from '../components/Claims'
 import User from '../components/User'
 import Users from '../components/Users'
+import ClaimsPage from '../bindings/ClaimsPage'
 
 storiesOf('Welcome', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />);
 
@@ -22,14 +27,30 @@ storiesOf('Button', module)
     </Button>
   ));
 
+const claim1 = {id: 1, title: "Ducks are cool", slug: "ducks_are_cool"}
+const claim2 = {id: 2, title: "Geese are neat", slug: "geese_are_neat"}
+const user1 = {id: 1, firstName: "Travis", lastName: "Vachon", email: "dontatme@gmail.com"}
+
+
 storiesOf('Claims', module)
-  .add('with claims', () => <Claims claims={[{id: 1, title: "Ducks are cool", slug: "ducks_are_cool"}, {id: 2, title: "Geese are neat", slug: "geese_are_neat"}]}>
+  .add('with claims', () => <Claims claims={[claim1, claim2]}>
   </Claims>)
 
 storiesOf('User', module)
-  .add('with claims', () => <User claims={[{id: 1, title: "Ducks are cool", slug: "/ducks_are_cool"}, {id: 2, title: "Geese are neat", slug: "/geese_are_neat"}]}>
+  .add('with claims', () => <User claims={[claim1, claim2]}>
        </User>)
 
 storiesOf('Users', module)
-  .add('with users', () => <Users users={[{id: 1, firstName: "Travis", lastName: "Vachon", email: "dontatme@gmail.com"}]} >
+  .add('with users', () => <Users users={[user1]} >
        </Users>)
+
+const withMocks = (mocks) => apolloStorybookDecorator({ typeDefs, mocks})
+
+storiesOf('ClaimsPage', module)
+  .addDecorator(StoryRouter())
+  .addDecorator(withMocks({
+    Query: () => ({
+      claims: () => [claim1, claim2]
+    })
+  }))
+  .add('with claims', () => <ClaimsPage />)


### PR DESCRIPTION
Doing this right required us to refactor our Docker infrastructure so we could introduce a separate module for the GraphQL schema and make it available in both the UI and API projects. This Docker setup feels cleaner anyway.

Add an example of how to test Apollo-aware components.